### PR TITLE
Fix: Search Filter

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,7 +7,7 @@ const HomePage: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   useEffect(() => {
-    console.log('is this rendering');
+   
     const foundPoke = pokemonData.filter(pk => {
       return pk.name.toLowerCase().includes(searchTerm.toLowerCase());
     });
@@ -18,7 +18,7 @@ const HomePage: React.FC = () => {
   // useEffect(()=>{},[])
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    console.log(event.target.value);
+ 
     setSearchTerm(event.target.value);
   };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ const HomePage: React.FC = () => {
     });
 
     searchTerm === '' ? setPokemon(pokemonData) : setPokemon(foundPoke);
-  }, []);
+  }, [searchTerm]);
 
   // useEffect(()=>{},[])
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ const HomePage: React.FC = () => {
     });
 
     searchTerm === '' ? setPokemon(pokemonData) : setPokemon(foundPoke);
-  }, [searchTerm]);
+  }, []);
 
   // useEffect(()=>{},[])
 

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -11,7 +11,7 @@ const SinglePokemonPage: React.FC = () => {
     let foundPokemon = pokemonData.find(
       pd => pd.name.toLowerCase() === pokemonName
     );
-    console.log(foundPokemon);
+    
     setPokemon(updateEvolution(foundPokemon));
   }, [pokemonName]);
 
@@ -45,7 +45,7 @@ const SinglePokemonPage: React.FC = () => {
       });
     }
 
-    console.log(poke);
+  
     return poke;
   };
   return (

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -112,7 +112,7 @@ const SinglePokemonPage: React.FC = () => {
                     <div className='row'>
                       {pokemon.prev_evolution?.map((pe, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col' key={i}>
                             <h5 className='text-secondary'>
                               Previous Evolution
                             </h5>
@@ -127,7 +127,7 @@ const SinglePokemonPage: React.FC = () => {
                       })}
                       {pokemon.next_evolution?.map((ne, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col' key={i}>
                             <h5 className='text-secondary'>Next Evolution</h5>
                             <div>
                               <Link to={`/pokemon/${ne.name.toLowerCase()}`}>


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. added dependency for the useEffect


## Purpose
-User was unable to search for particular pokemon

## Approach
-By adding the search Term as a dependency when we render the page, we are able to filter out the specific pokemon

## Learning
-When we use useEffect we can implement necessary effect/functionalities as dependencies  for our page.

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #01